### PR TITLE
feat: per-repo colors and review state fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Package.resolved
 
 # Environment
 .env
+
+# Superpowers
+.superpowers/

--- a/PRNotifier/PRNotifier.xcodeproj/project.pbxproj
+++ b/PRNotifier/PRNotifier.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		7810D93EC8BB09C1836EDA71 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20BD5AAF2E10C76397D7BC42 /* SettingsView.swift */; };
 		82DC126AEDBD426023A5F333 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C88AC7D4D95276538EA9F8FC /* NotificationService.swift */; };
 		979B4F7E32B9C84EE21ADA11 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7AA7D7828EC7B0D0F7EE7A1 /* AppSettings.swift */; };
+		9B4EF8BD19A16C2F6C435A4C /* RepoColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04A0B6697F51CF8DB2347CBB /* RepoColor.swift */; };
 		9C4CEBAFE828F295479216E4 /* DeviceFlowService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDB9DBB38763E12D176CA58 /* DeviceFlowService.swift */; };
 		A12703C50147B69A3D54910E /* PRNotifierApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB12FF989CC5332C40196DBE /* PRNotifierApp.swift */; };
 		A19F5989D89640F679C6FA39 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 928BD185D1F6953A052AE339 /* Assets.xcassets */; };
@@ -36,6 +37,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		04A0B6697F51CF8DB2347CBB /* RepoColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepoColor.swift; sourceTree = "<group>"; };
 		20BD5AAF2E10C76397D7BC42 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		213AF4149CFA6E62F6C9CD46 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		2EE3BDC521FD1D9FA78B8824 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -87,6 +89,7 @@
 				54C7C0006D42531CCF7080A6 /* InputValidation.swift */,
 				F7E422FA488CCC18896757D8 /* OAuthConfig.swift */,
 				751378E9A5F234D6A5804CD6 /* PR.swift */,
+				04A0B6697F51CF8DB2347CBB /* RepoColor.swift */,
 				98BF1076CB89563FAC056E1A /* ReviewInfo.swift */,
 			);
 			path = Models;
@@ -258,6 +261,7 @@
 				A12703C50147B69A3D54910E /* PRNotifierApp.swift in Sources */,
 				6A9C03E0B1292CE9E2915D49 /* PRViewModel.swift in Sources */,
 				B991AA3BC02DB6EA9D3C7E23 /* PersistenceManager.swift in Sources */,
+				9B4EF8BD19A16C2F6C435A4C /* RepoColor.swift in Sources */,
 				DD3AB4F355A32E7A8777E1DD /* ReviewBadgeView.swift in Sources */,
 				C5D2581BEBE27AE0422943CB /* ReviewInfo.swift in Sources */,
 				7810D93EC8BB09C1836EDA71 /* SettingsView.swift in Sources */,

--- a/PRNotifier/PRNotifier/Models/AppSettings.swift
+++ b/PRNotifier/PRNotifier/Models/AppSettings.swift
@@ -90,26 +90,38 @@ final class AppSettings {
         return true
     }
 
+    /// Returns the color for a repo without mutating state. Safe to call from view body.
     func colorForRepo(_ repo: String) -> RepoColor {
         if let existing = repoColors[repo] {
             return existing
         }
-
+        // Deterministic fallback: first unused palette color
         let usedColors = Set(repoColors.values)
-        let assigned = RepoColor.allCases.first { !usedColors.contains($0) }
+        return RepoColor.allCases.first { !usedColors.contains($0) }
             ?? RepoColor.allCases[repoColors.count % RepoColor.allCases.count]
+    }
 
-        repoColors[repo] = assigned
-        return assigned
+    /// Assigns and persists a color for a repo. Call at mutation points (addRepo, init).
+    @discardableResult
+    func assignColorForRepo(_ repo: String) -> RepoColor {
+        if let existing = repoColors[repo] {
+            return existing
+        }
+        let color = colorForRepo(repo)
+        repoColors[repo] = color
+        return color
     }
 
     init() {
         // Load stored values (must set all stored properties before didSet can fire)
+        let loadedRepos: [String]
         if let data = defaults.data(forKey: Keys.repos),
            let decoded = try? JSONDecoder().decode([String].self, from: data) {
             self.repos = decoded
+            loadedRepos = decoded
         } else {
             self.repos = []
+            loadedRepos = []
         }
         self.username = defaults.string(forKey: Keys.username) ?? ""
         let interval = defaults.integer(forKey: Keys.checkInterval)
@@ -121,7 +133,9 @@ final class AppSettings {
         self.oauthUsername = defaults.string(forKey: Keys.oauthUsername) ?? ""
         if let data = defaults.data(forKey: Keys.repoColors),
            let decoded = try? JSONDecoder().decode([String: RepoColor].self, from: data) {
-            self.repoColors = decoded
+            // Filter stale entries and keep only configured repos
+            let repoSet = Set(loadedRepos)
+            self.repoColors = decoded.filter { repoSet.contains($0.key) }
         } else {
             self.repoColors = [:]
         }
@@ -147,6 +161,11 @@ final class AppSettings {
             }
         } else {
             self.authMethod = .oauth
+        }
+
+        // Eagerly assign colors for any repos that don't have one yet
+        for repo in loadedRepos {
+            assignColorForRepo(repo)
         }
     }
 }

--- a/PRNotifier/PRNotifier/Models/AppSettings.swift
+++ b/PRNotifier/PRNotifier/Models/AppSettings.swift
@@ -19,6 +19,7 @@ final class AppSettings {
         static let devShowSamplePRs = "devShowSamplePRs"
         static let authMethod = "authMethod"
         static let oauthUsername = "oauthUsername"
+        static let repoColors = "repoColors"
     }
 
     var repos: [String] {
@@ -26,6 +27,9 @@ final class AppSettings {
             if let data = try? JSONEncoder().encode(repos) {
                 defaults.set(data, forKey: Keys.repos)
             }
+            // Remove color entries for repos no longer in the list
+            let repoSet = Set(repos)
+            repoColors = repoColors.filter { repoSet.contains($0.key) }
         }
     }
 
@@ -61,6 +65,14 @@ final class AppSettings {
         didSet { defaults.set(oauthUsername, forKey: Keys.oauthUsername) }
     }
 
+    var repoColors: [String: RepoColor] {
+        didSet {
+            if let data = try? JSONEncoder().encode(repoColors) {
+                defaults.set(data, forKey: Keys.repoColors)
+            }
+        }
+    }
+
     /// The effective username -- OAuth auto-populates, PAT requires manual entry.
     var effectiveUsername: String {
         switch authMethod {
@@ -76,6 +88,19 @@ final class AppSettings {
             return false
         }
         return true
+    }
+
+    func colorForRepo(_ repo: String) -> RepoColor {
+        if let existing = repoColors[repo] {
+            return existing
+        }
+
+        let usedColors = Set(repoColors.values)
+        let assigned = RepoColor.allCases.first { !usedColors.contains($0) }
+            ?? RepoColor.allCases[repoColors.count % RepoColor.allCases.count]
+
+        repoColors[repo] = assigned
+        return assigned
     }
 
     init() {
@@ -94,6 +119,12 @@ final class AppSettings {
         self.settingsPrompted = defaults.bool(forKey: Keys.settingsPrompted)
         self.devShowSamplePRs = defaults.bool(forKey: Keys.devShowSamplePRs)
         self.oauthUsername = defaults.string(forKey: Keys.oauthUsername) ?? ""
+        if let data = defaults.data(forKey: Keys.repoColors),
+           let decoded = try? JSONDecoder().decode([String: RepoColor].self, from: data) {
+            self.repoColors = decoded
+        } else {
+            self.repoColors = [:]
+        }
 
         // Determine auth method: check stored preference, then infer from existing tokens.
         // Only probe the keychain for legacy migration (user has config but no stored

--- a/PRNotifier/PRNotifier/Models/RepoColor.swift
+++ b/PRNotifier/PRNotifier/Models/RepoColor.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+enum RepoColor: String, Codable, CaseIterable {
+    case blue, green, orange, red, purple, pink, teal, yellow
+
+    var swiftUIColor: Color {
+        switch self {
+        case .blue: Color(red: 0.0, green: 0.478, blue: 1.0)
+        case .green: Color(red: 0.204, green: 0.780, blue: 0.349)
+        case .orange: Color(red: 1.0, green: 0.584, blue: 0.0)
+        case .red: Color(red: 1.0, green: 0.231, blue: 0.188)
+        case .purple: Color(red: 0.686, green: 0.322, blue: 0.871)
+        case .pink: Color(red: 1.0, green: 0.176, blue: 0.333)
+        case .teal: Color(red: 0.353, green: 0.784, blue: 0.980)
+        case .yellow: Color(red: 1.0, green: 0.8, blue: 0.0)
+        }
+    }
+}

--- a/PRNotifier/PRNotifier/Services/GitHubService.swift
+++ b/PRNotifier/PRNotifier/Services/GitHubService.swift
@@ -494,7 +494,8 @@ struct GitHubService {
     ) -> [ReviewInfo] {
         var reviewerMap: [String: ReviewInfo] = [:]
 
-        // Process reviews -- latest review wins (API returns chronological order)
+        // Process reviews -- latest review wins, except COMMENTED never
+        // overrides a decisive state (APPROVED/CHANGES_REQUESTED).
         for review in reviews {
             guard let user = review.user else { continue }
 
@@ -504,6 +505,13 @@ struct GitHubService {
             case "CHANGES_REQUESTED": state = .changesRequested
             case "COMMENTED": state = .commented
             default: state = .pending
+            }
+
+            // Don't let a comment downgrade an approval or change-request
+            if state == .commented,
+               let existing = reviewerMap[user.login],
+               existing.state == .approved || existing.state == .changesRequested {
+                continue
             }
 
             reviewerMap[user.login] = ReviewInfo(

--- a/PRNotifier/PRNotifier/Services/GitHubService.swift
+++ b/PRNotifier/PRNotifier/Services/GitHubService.swift
@@ -497,13 +497,12 @@ struct GitHubService {
         // Process reviews -- latest review wins (API returns chronological order)
         for review in reviews {
             guard let user = review.user else { continue }
-            // Skip COMMENTED state per Electron logic
-            guard review.state != "COMMENTED" else { continue }
 
             let state: ReviewState
             switch review.state {
             case "APPROVED": state = .approved
             case "CHANGES_REQUESTED": state = .changesRequested
+            case "COMMENTED": state = .commented
             default: state = .pending
             }
 

--- a/PRNotifier/PRNotifier/Views/PRCardView.swift
+++ b/PRNotifier/PRNotifier/Views/PRCardView.swift
@@ -7,6 +7,8 @@ struct PRCardView: View {
     var onDismiss: (() -> Void)?
     var onRestore: (() -> Void)?
 
+    @Environment(AppSettings.self) private var settings
+
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             if showReviewStatus && pr.isReadyToMerge {
@@ -54,8 +56,8 @@ struct PRCardView: View {
                     .fontWeight(.medium)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
-                    .background(isDismissed ? Color.gray.opacity(0.1) : Color.accentColor.opacity(0.1))
-                    .foregroundStyle(isDismissed ? Color.secondary : Color.accentColor)
+                    .background(isDismissed ? Color.gray.opacity(0.1) : settings.colorForRepo(pr.repo).swiftUIColor.opacity(0.1))
+                    .foregroundStyle(isDismissed ? Color.secondary : settings.colorForRepo(pr.repo).swiftUIColor)
                     .clipShape(Capsule())
 
                 Text(verbatim: "#\(pr.number)")

--- a/PRNotifier/PRNotifier/Views/PRCardView.swift
+++ b/PRNotifier/PRNotifier/Views/PRCardView.swift
@@ -50,14 +50,15 @@ struct PRCardView: View {
             }
 
             // Repo badge + PR number
+            let repoColor = settings.colorForRepo(pr.repo).swiftUIColor
             HStack(spacing: 6) {
                 Text(pr.repo)
                     .font(.caption)
                     .fontWeight(.medium)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 3)
-                    .background(isDismissed ? Color.gray.opacity(0.1) : settings.colorForRepo(pr.repo).swiftUIColor.opacity(0.1))
-                    .foregroundStyle(isDismissed ? Color.secondary : settings.colorForRepo(pr.repo).swiftUIColor)
+                    .background(isDismissed ? Color.gray.opacity(0.1) : repoColor.opacity(0.1))
+                    .foregroundStyle(isDismissed ? Color.secondary : repoColor)
                     .clipShape(Capsule())
 
                 Text(verbatim: "#\(pr.number)")

--- a/PRNotifier/PRNotifier/Views/PRCardView.swift
+++ b/PRNotifier/PRNotifier/Views/PRCardView.swift
@@ -58,7 +58,7 @@ struct PRCardView: View {
                     .foregroundStyle(isDismissed ? Color.secondary : Color.accentColor)
                     .clipShape(Capsule())
 
-                Text("#\(pr.number)")
+                Text(verbatim: "#\(pr.number)")
                     .font(.caption)
                     .foregroundStyle(.secondary)
 

--- a/PRNotifier/PRNotifier/Views/SettingsView.swift
+++ b/PRNotifier/PRNotifier/Views/SettingsView.swift
@@ -346,6 +346,7 @@ struct SettingsView: View {
         }
 
         repos.append(trimmed)
+        _ = settings.colorForRepo(trimmed)
         newRepo = ""
     }
 

--- a/PRNotifier/PRNotifier/Views/SettingsView.swift
+++ b/PRNotifier/PRNotifier/Views/SettingsView.swift
@@ -346,7 +346,7 @@ struct SettingsView: View {
         }
 
         repos.append(trimmed)
-        _ = settings.colorForRepo(trimmed)
+        settings.assignColorForRepo(trimmed)
         newRepo = ""
     }
 

--- a/PRNotifier/PRNotifier/Views/SettingsView.swift
+++ b/PRNotifier/PRNotifier/Views/SettingsView.swift
@@ -21,6 +21,7 @@ struct SettingsView: View {
     @State private var showSaveConfirmation = false
     @State private var showOAuthSheet = false
     @State private var showPATSection = false
+    @State private var colorPickerRepo: String?
 
     var body: some View {
         Form {
@@ -51,7 +52,24 @@ struct SettingsView: View {
                     Text(error).font(.caption).foregroundStyle(.red)
                 }
                 ForEach(repos, id: \.self) { repo in
-                    HStack {
+                    HStack(spacing: 10) {
+                        Circle()
+                            .fill(settings.colorForRepo(repo).swiftUIColor)
+                            .frame(width: 20, height: 20)
+                            .overlay(
+                                Circle()
+                                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
+                            )
+                            .onTapGesture {
+                                colorPickerRepo = colorPickerRepo == repo ? nil : repo
+                            }
+                            .popover(isPresented: Binding(
+                                get: { colorPickerRepo == repo },
+                                set: { if !$0 { colorPickerRepo = nil } }
+                            )) {
+                                repoColorPicker(for: repo)
+                            }
+
                         Text(repo)
                             .font(.body)
                         Spacer()
@@ -476,6 +494,31 @@ struct SettingsView: View {
         } catch {
             raycastInstallResult = .failure("Failed: \(error.localizedDescription)")
         }
+    }
+
+    // MARK: - Color Picker
+
+    private func repoColorPicker(for repo: String) -> some View {
+        let columns = Array(repeating: GridItem(.fixed(28), spacing: 8), count: 4)
+
+        return LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(RepoColor.allCases, id: \.self) { color in
+                Circle()
+                    .fill(color.swiftUIColor)
+                    .frame(width: 28, height: 28)
+                    .overlay(
+                        Circle()
+                            .strokeBorder(Color.primary.opacity(
+                                settings.repoColors[repo] == color ? 0.6 : 0.15
+                            ), lineWidth: settings.repoColors[repo] == color ? 2 : 1)
+                    )
+                    .onTapGesture {
+                        settings.repoColors[repo] = color
+                        colorPickerRepo = nil
+                    }
+            }
+        }
+        .padding(12)
     }
 
     // MARK: - Auto-launch

--- a/docs/superpowers/plans/2026-04-10-per-repo-colors.md
+++ b/docs/superpowers/plans/2026-04-10-per-repo-colors.md
@@ -1,0 +1,344 @@
+# Per-Repo Colors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give each monitored repository its own color in the PR card repo badge and let users configure it in settings.
+
+**Architecture:** A `RepoColor` enum defines 8 preset colors. `AppSettings` stores a `[String: RepoColor]` mapping in UserDefaults and provides a `colorForRepo(_:)` helper that auto-assigns colors. `PRCardView` reads the color from settings. `SettingsView` adds an inline color picker popover per repo row.
+
+**Tech Stack:** Swift 5.9, SwiftUI, UserDefaults
+
+---
+
+### Task 1: Add `RepoColor` enum
+
+**Files:**
+- Create: `PRNotifier/PRNotifier/Models/RepoColor.swift`
+
+- [ ] **Step 1: Create `RepoColor.swift`**
+
+Create `PRNotifier/PRNotifier/Models/RepoColor.swift`:
+
+```swift
+import SwiftUI
+
+enum RepoColor: String, Codable, CaseIterable {
+    case blue, green, orange, red, purple, pink, teal, yellow
+
+    var swiftUIColor: Color {
+        switch self {
+        case .blue: Color(red: 0.0, green: 0.478, blue: 1.0)
+        case .green: Color(red: 0.204, green: 0.780, blue: 0.349)
+        case .orange: Color(red: 1.0, green: 0.584, blue: 0.0)
+        case .red: Color(red: 1.0, green: 0.231, blue: 0.188)
+        case .purple: Color(red: 0.686, green: 0.322, blue: 0.871)
+        case .pink: Color(red: 1.0, green: 0.176, blue: 0.333)
+        case .teal: Color(red: 0.353, green: 0.784, blue: 0.980)
+        case .yellow: Color(red: 1.0, green: 0.8, blue: 0.0)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `xcodebuild -project PRNotifier/PRNotifier.xcodeproj -scheme PRNotifier -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Regenerate Xcode project**
+
+XcodeGen auto-discovers source files, so the new file needs a project regenerate:
+
+Run: `cd PRNotifier && xcodegen generate`
+Expected: `Generated PRNotifier project`
+
+- [ ] **Step 4: Build again after regeneration**
+
+Run: `xcodebuild -project PRNotifier/PRNotifier.xcodeproj -scheme PRNotifier -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PRNotifier/PRNotifier/Models/RepoColor.swift PRNotifier/PRNotifier.xcodeproj
+git commit -m "feat: add RepoColor enum with 8 preset palette colors"
+```
+
+---
+
+### Task 2: Add color storage and auto-assignment to `AppSettings`
+
+**Files:**
+- Modify: `PRNotifier/PRNotifier/Models/AppSettings.swift`
+
+- [ ] **Step 1: Add `repoColors` key and stored property**
+
+In `AppSettings.swift`, add to the `Keys` enum:
+
+```swift
+static let repoColors = "repoColors"
+```
+
+Add a new stored property after `oauthUsername`:
+
+```swift
+var repoColors: [String: RepoColor] {
+    didSet {
+        if let data = try? JSONEncoder().encode(repoColors) {
+            defaults.set(data, forKey: Keys.repoColors)
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Load `repoColors` in `init()`**
+
+In `init()`, after the line `self.oauthUsername = defaults.string(forKey: Keys.oauthUsername) ?? ""`, add:
+
+```swift
+if let data = defaults.data(forKey: Keys.repoColors),
+   let decoded = try? JSONDecoder().decode([String: RepoColor].self, from: data) {
+    self.repoColors = decoded
+} else {
+    self.repoColors = [:]
+}
+```
+
+- [ ] **Step 3: Add `colorForRepo(_:)` method**
+
+Add this method after the `isConfigured` computed property:
+
+```swift
+func colorForRepo(_ repo: String) -> RepoColor {
+    if let existing = repoColors[repo] {
+        return existing
+    }
+
+    let usedColors = Set(repoColors.values)
+    let assigned = RepoColor.allCases.first { !usedColors.contains($0) }
+        ?? RepoColor.allCases[repoColors.count % RepoColor.allCases.count]
+
+    repoColors[repo] = assigned
+    return assigned
+}
+```
+
+- [ ] **Step 4: Clean up stale colors when repos change**
+
+In the `repos` property's `didSet`, after the existing `defaults.set(data, ...)` call, add cleanup logic. Replace the entire `repos` didSet:
+
+```swift
+var repos: [String] {
+    didSet {
+        if let data = try? JSONEncoder().encode(repos) {
+            defaults.set(data, forKey: Keys.repos)
+        }
+        // Remove color entries for repos no longer in the list
+        let repoSet = Set(repos)
+        repoColors = repoColors.filter { repoSet.contains($0.key) }
+    }
+}
+```
+
+- [ ] **Step 5: Build to verify**
+
+Run: `xcodebuild -project PRNotifier/PRNotifier.xcodeproj -scheme PRNotifier -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PRNotifier/PRNotifier/Models/AppSettings.swift
+git commit -m "feat: add repoColors storage and auto-assignment to AppSettings"
+```
+
+---
+
+### Task 3: Use repo color in `PRCardView`
+
+**Files:**
+- Modify: `PRNotifier/PRNotifier/Views/PRCardView.swift`
+
+- [ ] **Step 1: Add `AppSettings` environment dependency**
+
+At the top of `PRCardView`, after the existing properties (line 4-8), add:
+
+```swift
+@Environment(AppSettings.self) private var settings
+```
+
+- [ ] **Step 2: Replace accent color with repo color in the badge**
+
+Replace the repo badge block (lines 52-59) from:
+
+```swift
+Text(pr.repo)
+    .font(.caption)
+    .fontWeight(.medium)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 3)
+    .background(isDismissed ? Color.gray.opacity(0.1) : Color.accentColor.opacity(0.1))
+    .foregroundStyle(isDismissed ? Color.secondary : Color.accentColor)
+    .clipShape(Capsule())
+```
+
+to:
+
+```swift
+Text(pr.repo)
+    .font(.caption)
+    .fontWeight(.medium)
+    .padding(.horizontal, 8)
+    .padding(.vertical, 3)
+    .background(isDismissed ? Color.gray.opacity(0.1) : settings.colorForRepo(pr.repo).swiftUIColor.opacity(0.1))
+    .foregroundStyle(isDismissed ? Color.secondary : settings.colorForRepo(pr.repo).swiftUIColor)
+    .clipShape(Capsule())
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `xcodebuild -project PRNotifier/PRNotifier.xcodeproj -scheme PRNotifier -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Manual test with sample PRs**
+
+Launch the app, enable "Show sample PRs" in Developer Options. Verify:
+- Each repo (`sample/repo`, `another/project`, `docs/documentation`, `docs/api-docs`) has a distinct colored badge
+- Dismissed PRs still show gray badges
+- Colors are consistent across tabs (same repo = same color)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PRNotifier/PRNotifier/Views/PRCardView.swift
+git commit -m "feat: use per-repo colors in PR card badges"
+```
+
+---
+
+### Task 4: Add inline color picker to `SettingsView`
+
+**Files:**
+- Modify: `PRNotifier/PRNotifier/Views/SettingsView.swift`
+
+- [ ] **Step 1: Add local state for the color picker popover**
+
+In `SettingsView`, after the existing `@State` properties (around line 23), add:
+
+```swift
+@State private var colorPickerRepo: String?
+```
+
+- [ ] **Step 2: Replace the repo row with a color-picker-enabled version**
+
+Replace the `ForEach(repos, id: \.self)` block (lines 53-68) with:
+
+```swift
+ForEach(repos, id: \.self) { repo in
+    HStack(spacing: 10) {
+        Circle()
+            .fill(settings.colorForRepo(repo).swiftUIColor)
+            .frame(width: 20, height: 20)
+            .overlay(
+                Circle()
+                    .strokeBorder(Color.primary.opacity(0.15), lineWidth: 1)
+            )
+            .onTapGesture {
+                colorPickerRepo = colorPickerRepo == repo ? nil : repo
+            }
+            .popover(isPresented: Binding(
+                get: { colorPickerRepo == repo },
+                set: { if !$0 { colorPickerRepo = nil } }
+            )) {
+                repoColorPicker(for: repo)
+            }
+
+        Text(repo)
+            .font(.body)
+        Spacer()
+        Button {
+            if let index = repos.firstIndex(of: repo) {
+                repos.remove(at: index)
+            }
+        } label: {
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 3: Add the `repoColorPicker` helper view**
+
+Add this private method at the bottom of `SettingsView`, before the closing `}` of the struct (but after `updateAutoLaunch`):
+
+```swift
+private func repoColorPicker(for repo: String) -> some View {
+    let columns = Array(repeating: GridItem(.fixed(28), spacing: 8), count: 4)
+
+    return LazyVGrid(columns: columns, spacing: 8) {
+        ForEach(RepoColor.allCases, id: \.self) { color in
+            Circle()
+                .fill(color.swiftUIColor)
+                .frame(width: 28, height: 28)
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.primary.opacity(
+                            settings.repoColors[repo] == color ? 0.6 : 0.15
+                        ), lineWidth: settings.repoColors[repo] == color ? 2 : 1)
+                )
+                .onTapGesture {
+                    settings.repoColors[repo] = color
+                    colorPickerRepo = nil
+                }
+        }
+    }
+    .padding(12)
+}
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `xcodebuild -project PRNotifier/PRNotifier.xcodeproj -scheme PRNotifier -configuration Debug build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 5: Manual test**
+
+Launch the app, go to Settings > Repositories. Verify:
+- Each repo has a colored circle to its left
+- Tapping the circle opens a popover with 8 color swatches
+- Tapping a swatch changes the repo's color and closes the popover
+- The color change is reflected immediately in the PR list
+- Adding a new repo auto-assigns a color and shows the dot
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PRNotifier/PRNotifier/Views/SettingsView.swift
+git commit -m "feat: add inline repo color picker to settings"
+```
+
+---
+
+### Task 5: Regenerate Xcode project and final verification
+
+**Files:**
+- Modify: `PRNotifier/PRNotifier.xcodeproj` (regenerated)
+
+- [ ] **Step 1: Regenerate Xcode project**
+
+Run: `cd PRNotifier && xcodegen generate`
+Expected: `Generated PRNotifier project`
+
+- [ ] **Step 2: Clean build**
+
+Run: `xcodebuild -project PRNotifier/PRNotifier.xcodeproj -scheme PRNotifier -configuration Debug clean build 2>&1 | tail -5`
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 3: Commit if project file changed**
+
+```bash
+git add PRNotifier/PRNotifier.xcodeproj
+git commit -m "chore: regenerate Xcode project with RepoColor model"
+```

--- a/docs/superpowers/specs/2026-04-10-per-repo-colors-design.md
+++ b/docs/superpowers/specs/2026-04-10-per-repo-colors-design.md
@@ -1,0 +1,76 @@
+# Per-Repo Color Design
+
+Each monitored repository gets its own color so users can visually distinguish repos when scanning PR cards.
+
+## Color Palette
+
+8 preset colors based on standard macOS system colors, assigned in this order:
+
+1. Blue (`#007AFF`)
+2. Green (`#34C759`)
+3. Orange (`#FF9500`)
+4. Red (`#FF3B30`)
+5. Purple (`#AF52DE`)
+6. Pink (`#FF2D55`)
+7. Teal (`#5AC8FA`)
+8. Yellow (`#FFCC00`)
+
+If all 8 are in use, assignment cycles from the beginning.
+
+## Data Model
+
+### `RepoColor` enum (new file: `Models/RepoColor.swift`)
+
+```swift
+enum RepoColor: String, Codable, CaseIterable {
+    case blue, green, orange, red, purple, pink, teal, yellow
+
+    var swiftUIColor: Color { ... }
+}
+```
+
+Maps each case to its corresponding SwiftUI `Color` value.
+
+### `AppSettings` changes
+
+New stored property:
+
+```swift
+var repoColors: [String: RepoColor]  // persisted in UserDefaults as JSON
+```
+
+New helper method:
+
+```swift
+func colorForRepo(_ repo: String) -> RepoColor
+```
+
+Returns the stored color for a repo. If none is stored, auto-assigns the first palette color not already in use (by iterating `RepoColor.allCases` and checking which are absent from the current `repoColors` values). Persists the assignment immediately. If all colors are taken, cycles from the beginning.
+
+Also cleans up stale entries: when `repos` is set, any `repoColors` keys not in the new repo list are removed.
+
+## UI Changes
+
+### PR Card (`PRCardView.swift`)
+
+The repo badge (lines 52-59) currently uses `Color.accentColor` for background and foreground. Change to use the repo's assigned color:
+
+- Background: `repoColor.opacity(0.1)` (unchanged pattern, new color source)
+- Foreground: `repoColor` (unchanged pattern, new color source)
+- Dismissed state remains gray (unchanged)
+
+The view needs access to `AppSettings` via `@Environment(AppSettings.self)`. This is a new dependency for `PRCardView` -- `AppSettings` is already injected into the environment at the app level, so no changes needed to parent views.
+
+### Settings (`SettingsView.swift`)
+
+Each repo row in the Repositories section gains a color indicator dot (20x20 circle) to the left of the repo name. Tapping the dot opens a popover containing the 8 palette swatches. Tapping a swatch updates the color and dismisses the popover.
+
+The color dot reflects the current assignment. New repos get auto-assigned on add.
+
+## Auto-Assignment Behavior
+
+When a repo is added (via `addRepo()` in settings), `colorForRepo()` is called to assign a color before the save. This ensures every repo in the list always has a visible color dot.
+
+## Testing
+
+Verify with the existing "Show sample PRs" developer toggle -- sample PRs use repos like `[SAMPLE]` prefixed names. Each should get a distinct color.


### PR DESCRIPTION
## Summary

- **Per-repo colors**: Each monitored repo gets its own color in the PR card badge, configurable via an inline color picker in settings. 8 preset macOS system colors auto-assigned on add, user can change via popover.
- **Review state fix**: COMMENTED reviews no longer override APPROVED/CHANGES_REQUESTED state, preventing false loss of approval status.
- **PR number formatting**: Display as `#1234` instead of `#1,234`.

## Changes

- New `RepoColor` enum with 8 preset palette colors
- `AppSettings` gains `repoColors` storage with auto-assignment and stale cleanup
- `PRCardView` badge uses per-repo color instead of accent color
- `SettingsView` gets inline color dot + popover picker per repo row
- `buildReviewInfos` treats COMMENTED as non-overriding of decisive review states
- `Text(verbatim:)` for PR number to avoid locale formatting

## Test plan

- [ ] Enable "Show sample PRs" in Developer Options -- verify each repo has a distinct badge color
- [ ] In Settings, verify colored dots appear next to each repo
- [ ] Tap a color dot -- verify popover shows 8 swatches with current selection highlighted
- [ ] Change a color -- verify it updates immediately in the PR list
- [ ] Add a new repo -- verify it auto-assigns an unused color
- [ ] Remove a repo and re-add -- verify stale colors are cleaned up
- [ ] Verify dismissed PRs still show gray badges
- [ ] Verify PR numbers display without commas (e.g. `#1234` not `#1,234`)